### PR TITLE
s3 deploy changes

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -6,7 +6,8 @@ var path = require("path");
 var creds = {
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  region: process.env.AWS_DEFAULT_REGION || "us-east-1"
+  region: process.env.AWS_DEFAULT_REGION || "us-east-1",
+  sessionToken: process.env.AWS_SESSION_TOKEN
 };
 aws.config.update(creds);
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "eval \"`aws-auth-helper prodbeanstalk`\" node .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node .",
     "dev": "nodemon .",
     "install": "cp -n config.json.example config.json || true"
   },
@@ -15,6 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
+    "aws-auth-helper": "^1.0.0",
     "aws-sdk": "^2.359.0",
     "babelify": "^10.0.0",
     "body-parser": "^1.18.3",


### PR DESCRIPTION
Adds [aws-auth-helper](https://www.npmjs.com/package/aws-auth-helper) package and session token line to s3.js, allowing MFA on npm start command.